### PR TITLE
Add support for intercepting routes

### DIFF
--- a/src/cli/utils/getRoute.test.ts
+++ b/src/cli/utils/getRoute.test.ts
@@ -16,6 +16,25 @@ const inputRewrites: Rewrite[] = [
     originPath: '/blog/[authorId]/[articleId]/page.ts',
     localizedPath: '/en/blog/[authorId]/[articleId]/page.ts',
   },
+  {
+    originPath: '/@modal/(.)blog/[authorId]/[articleId]/page.ts',
+    localizedPath: '/en/@modal/(.)blog/[authorId]/[articleId]/page.ts',
+  },
+  {
+    originPath: '/feed/@modal/(..)blog/[authorId]/[articleId]/page.ts',
+    localizedPath: '/en/feed/@modal/(..)blog/[authorId]/[articleId]/page.ts',
+  },
+  {
+    originPath:
+      '/feed/friends/@modal/(..)(..)blog/[authorId]/[articleId]/page.ts',
+    localizedPath:
+      '/en/feed/friends/@modal/(..)(..)blog/[authorId]/[articleId]/page.ts',
+  },
+  {
+    originPath: '/feed/friends/@modal/(...)blog/[authorId]/[articleId]/page.ts',
+    localizedPath:
+      '/en/feed/friends/@modal/(...)blog/[authorId]/[articleId]/page.ts',
+  },
   { originPath: '/page.js', localizedPath: '/en/page.js' },
   { originPath: '/page.js', localizedPath: '/(en)/page.js' },
 ]
@@ -23,12 +42,28 @@ const inputRewrites: Rewrite[] = [
 const expectedSchema: Array<Route | undefined> = [
   undefined,
   {
-    name: '/(auth)/login',
+    name: '/login',
     href: '/en/log-in',
   },
   {
-    name: '/@header/login',
+    name: '/login',
     href: '/en/log-in',
+  },
+  {
+    name: '/blog/[authorId]/[articleId]',
+    href: '/en/blog/:authorId/:articleId',
+  },
+  {
+    name: '/blog/[authorId]/[articleId]',
+    href: '/en/blog/:authorId/:articleId',
+  },
+  {
+    name: '/blog/[authorId]/[articleId]',
+    href: '/en/blog/:authorId/:articleId',
+  },
+  {
+    name: '/blog/[authorId]/[articleId]',
+    href: '/en/blog/:authorId/:articleId',
   },
   {
     name: '/blog/[authorId]/[articleId]',

--- a/src/cli/utils/getRouterSchema.test.ts
+++ b/src/cli/utils/getRouterSchema.test.ts
@@ -3,15 +3,19 @@ import { getRouterSchema } from './getRouterSchema'
 
 const inputRoutes: Route[] = [
   {
-    name: '/(auth)/login',
+    name: '/login',
     href: '/log-in',
   },
   {
-    name: '/(auth)/login',
+    name: '/login',
+    href: '/log-in',
+  },
+  {
+    name: '/login',
     href: '/cs/prihlaseni',
   },
   {
-    name: '/(auth)/login',
+    name: '/login',
     href: '/es/login',
   },
   {
@@ -34,7 +38,7 @@ const expectedSchema: RouterSchema = {
   routes: {
     en: [
       {
-        name: '/(auth)/login',
+        name: '/login',
         href: '/log-in',
       },
       {
@@ -44,7 +48,7 @@ const expectedSchema: RouterSchema = {
     ],
     es: [
       {
-        name: '/(auth)/login',
+        name: '/login',
         href: '/es/login',
       },
       {
@@ -54,7 +58,7 @@ const expectedSchema: RouterSchema = {
     ],
     cs: [
       {
-        name: '/(auth)/login',
+        name: '/login',
         href: '/cs/prihlaseni',
       },
       {

--- a/src/cli/utils/getRouterSchema.ts
+++ b/src/cli/utils/getRouterSchema.ts
@@ -19,7 +19,8 @@ export function getRouterSchema({
     const locale = getLocale(route.href) || defaultLocale
 
     const existingRoutes = schema.routes[locale] || []
-    schema.routes[locale] = [...existingRoutes, route]
+    const routeExists = existingRoutes.some(({ name }) => route.name === name)
+    if (!routeExists) schema.routes[locale] = [...existingRoutes, route]
   })
 
   return schema

--- a/src/utils/pipe-utils.ts
+++ b/src/utils/pipe-utils.ts
@@ -25,6 +25,14 @@ export function pipe<A, B, C, D, E, F>(
   fn4: (input: D) => E,
   fn5: (input: E) => F
 ): Fn<A, F>
+export function pipe<A, B, C, D, E, F, G>(
+  fn1: (input: A) => B,
+  fn2: (input: B) => C,
+  fn3: (input: C) => D,
+  fn4: (input: D) => E,
+  fn5: (input: E) => F,
+  fn6: (input: F) => G
+): Fn<A, G>
 
 export function pipe(...fns: Fn[]): unknown {
   return (input: unknown) => fns.reduce((acc, fn) => fn(acc), input)


### PR DESCRIPTION
I have implemented in this PR the support for intercepted routes. The Router's href will be set to the same href as it would be set when the page is reloaded. So the Router has the same href "/blog/:author" in the /@modal/(.)blog/[author]/page.tsx and /blog/[author]/page.tsx pages.

~~I had to write quite complicated RegExps for this functionality.~~ And there is also now some ordering dependancies between the piped functions in getRouteHref. For example, all group and parallel segments ~~(expect default locale "/(en)/" group segment)~~ have to be removed before intercepted segments can be removed properly.

~~Since now the default locale group segment "/(en)/" is not removed in the first removeGroupSegments call, it required it's own function to had it removed later in the pipe.~~

I will create a different pull request for the example update since it requires a new version of next-roots to be released.