### PR TITLE
Update example with parallel and intercepting routes

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "accept-language-parser": "^1.5.0",
     "clsx": "^1.2.1",
     "next": "^13.3.0",
-    "next-roots": "^3.0.5",
+    "next-roots": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "server-only": "^0.0.1"

--- a/example/src/features/blog/components/ArticleDetail.tsx
+++ b/example/src/features/blog/components/ArticleDetail.tsx
@@ -7,11 +7,13 @@ import { getDictionary } from 'src/server/utils/getDictionary'
 type ArticleDetailProps = {
   article: ArticleTranslation
   alternatives?: ReactNode
+  buttonBack?: ReactNode
 }
 
 export async function ArticleDetail({
   article,
   alternatives,
+  buttonBack,
 }: ArticleDetailProps) {
   const t = await getDictionary(article.locale)
   return (
@@ -38,15 +40,7 @@ export async function ArticleDetail({
               <p className="mt-2 text-xl leading-8 text-gray-700">
                 {article.content}
               </p>
-              <p className="mt-6">
-                <Link
-                  href={getHomeHref(article.locale)}
-                  role="button"
-                  className="rounded bg-indigo-600 px-4 py-2 text-base font-semibold leading-7 text-white"
-                >
-                  {t('article.BtnBack')}
-                </Link>
-              </p>
+              {buttonBack && <p className="mt-6">{buttonBack}</p>}
             </div>
           </div>
           {alternatives && <div className="mt-16 lg:mt-0 ">{alternatives}</div>}

--- a/example/src/features/blog/components/AuthorDetail.tsx
+++ b/example/src/features/blog/components/AuthorDetail.tsx
@@ -8,12 +8,14 @@ type AuthorDetailProps = {
   author: AuthorTranslation
   articles?: ReactNode
   alternatives?: ReactNode
+  buttonBack?: ReactNode
 }
 
 export async function AuthorDetail({
   author,
   articles,
   alternatives,
+  buttonBack,
 }: AuthorDetailProps) {
   const t = await getDictionary(author.locale)
   return (
@@ -28,15 +30,7 @@ export async function AuthorDetail({
               <p className="mt-4 text-xl leading-8 text-gray-700">
                 {author.about}
               </p>
-              <p className="mt-6">
-                <Link
-                  href={getHomeHref(author.locale)}
-                  role="button"
-                  className="rounded bg-indigo-600 px-4 py-2 text-base font-semibold leading-7 text-white"
-                >
-                  {t('author.BtnHome')}
-                </Link>
-              </p>
+              {buttonBack && <p className="mt-6">{buttonBack}</p>}
             </div>
           </div>
           <div className="mt-16 lg:mt-0">

--- a/example/src/features/common/components/BackButton.tsx
+++ b/example/src/features/common/components/BackButton.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+
+export function BackButton({ children }: { children: ReactNode }) {
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={router.back}
+      className="rounded bg-indigo-600 px-4 py-2 text-base font-semibold leading-7 text-white"
+    >
+      {children}
+    </button>
+  )
+}
+
+export default BackButton

--- a/example/src/features/common/components/Layout.tsx
+++ b/example/src/features/common/components/Layout.tsx
@@ -1,5 +1,5 @@
 import type { RouteLocale } from 'next-roots'
-import type { PropsWithChildren } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import { Nav } from './Nav'
 
 import Link from 'next/link'
@@ -8,7 +8,10 @@ import { getAboutHref, getContactsHref, getHomeHref } from 'src/server/router'
 import { getDictionary } from 'src/server/utils/getDictionary'
 import { Footer } from './Footer'
 
-type RootLayoutProps = PropsWithChildren<{ locale: RouteLocale }>
+type RootLayoutProps = PropsWithChildren<{
+  locale: RouteLocale
+  modal: ReactNode
+}>
 
 async function getNavigation(locale: string) {
   const t = await getDictionary(locale)
@@ -26,7 +29,7 @@ async function getNavigation(locale: string) {
  * @param param0
  * @returns
  */
-export async function Layout({ children, locale }: RootLayoutProps) {
+export async function Layout({ children, modal, locale }: RootLayoutProps) {
   const navigation = await getNavigation(locale)
 
   return (
@@ -40,6 +43,7 @@ export async function Layout({ children, locale }: RootLayoutProps) {
           <footer className="py-6">
             <Footer />
           </footer>
+          {modal}
         </div>
       </body>
     </html>

--- a/example/src/features/common/components/Links.tsx
+++ b/example/src/features/common/components/Links.tsx
@@ -16,7 +16,7 @@ export function Links({ header, items }: LinksProps) {
 
       <ul role="list" className="mt-4 text-indigo-600">
         {items.map((link) => (
-          <li key={link.locale} className="flex gap-x-1">
+          <li key={link.name} className="flex gap-x-1">
             <Link href={link.href}>{link.name}</Link>
           </li>
         ))}

--- a/example/src/features/common/components/Modal.tsx
+++ b/example/src/features/common/components/Modal.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import {
+  useCallback,
+  useRef,
+  useEffect,
+  ReactNode,
+  MouseEventHandler,
+} from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function Modal({ children }: { children: ReactNode }) {
+  const overlay = useRef<HTMLDivElement>(null)
+  const wrapper = useRef<HTMLDivElement>(null)
+  const router = useRouter()
+
+  const onClick: MouseEventHandler = (e) => {
+    if (e.target === overlay.current || e.target === wrapper.current) {
+      router.back()
+    }
+  }
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') router.back()
+    },
+    [router]
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onKeyDown])
+
+  return (
+    <div
+      ref={overlay}
+      className="fixed inset-0 z-10 mx-auto overflow-y-auto bg-black/60"
+      onClick={onClick}
+    >
+      <div
+        ref={wrapper}
+        className="absolute left-1/2 top-0 w-full max-w-7xl -translate-x-1/2 p-6 lg:top-1/2 lg:-translate-y-1/2 lg:px-8"
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/example/src/routes/@modal/(.)blogs/[author]/[article]/page.tsx
+++ b/example/src/routes/@modal/(.)blogs/[author]/[article]/page.tsx
@@ -1,0 +1,75 @@
+import type { GenerateStaticParamsProps, PageProps } from 'next-roots'
+import { notFound, redirect } from 'next/navigation'
+import { ArticleDetail } from 'src/features/blog/components/ArticleDetail'
+import { getArticleLinkParams } from 'src/features/blog/utils/getArticleLinkParams'
+import {
+  getAllArticleTranslations,
+  getArticleTranslation,
+} from 'src/features/blog/utils/getArticleTranslation'
+import BackButton from 'src/features/common/components/BackButton'
+import { Links } from 'src/features/common/components/Links'
+import Modal from 'src/features/common/components/Modal'
+import { fetchArticleBySlug, fetchArticles, fetchAuthors } from 'src/server/db'
+import { getArticleHref, router } from 'src/server/router'
+import { getDictionary } from 'src/server/utils/getDictionary'
+
+type AuthorArticleParams = { author: string; article: string }
+
+export default async function AuthorArticlePage({
+  params,
+  pageHref,
+}: PageProps<AuthorArticleParams>) {
+  const pageLocale = router.getLocaleFromHref(pageHref)
+  const article = await fetchArticleBySlug(params.article)
+
+  if (!article) {
+    return notFound()
+  }
+
+  const allArticleTranslations = getAllArticleTranslations(article)
+  const currentArticleTranslation = getArticleTranslation({
+    article,
+    locale: pageLocale,
+  })
+
+  if (!currentArticleTranslation) {
+    return notFound()
+  }
+
+  const href = getArticleHref(currentArticleTranslation)
+
+  if (pageHref !== href) {
+    return redirect(href)
+  }
+
+  const t = await getDictionary(pageLocale)
+
+  return (
+    <Modal>
+      <ArticleDetail
+        article={currentArticleTranslation}
+        alternatives={
+          <Links
+            header={t('common.NotYourLanguage?')}
+            items={allArticleTranslations.map(getArticleLinkParams)}
+          />
+        }
+        buttonBack={<BackButton>{t('article.BtnBack')}</BackButton>}
+      />
+    </Modal>
+  )
+}
+
+export async function generateStaticParams({
+  pageLocale,
+}: GenerateStaticParamsProps) {
+  const authors = await fetchAuthors()
+  const articles = await fetchArticles()
+
+  return articles
+    .map(({ slug, authorId }) => ({
+      author: authors.find(({ id }) => id === authorId)?.username,
+      article: slug.find(({ locale }) => locale === pageLocale)?.value,
+    }))
+    .filter((props) => props.article && props.author)
+}

--- a/example/src/routes/@modal/(.)blogs/[author]/page.tsx
+++ b/example/src/routes/@modal/(.)blogs/[author]/page.tsx
@@ -1,20 +1,16 @@
-import type { Metadata } from 'next'
-import type {
-  GenerateMetadataProps,
-  GenerateStaticParamsProps,
-  PageProps,
-} from 'next-roots'
+import type { GenerateStaticParamsProps, PageProps } from 'next-roots'
 import { notFound } from 'next/navigation'
 import { AuthorDetail } from 'src/features/blog/components/AuthorDetail'
 import { getArticleLinkParams } from 'src/features/blog/utils/getArticleLinkParams'
 import { getArticleTranslationFactory } from 'src/features/blog/utils/getArticleTranslation'
 import { getAuthorLinkParams } from 'src/features/blog/utils/getAuthorLinkParams'
-import { getAuthorMetadata } from 'src/features/blog/utils/getAuthorMetadata'
 import {
   getAllAuthorTranslations,
   getAuthorTranslation,
 } from 'src/features/blog/utils/getAuthorTranslation'
+import BackButton from 'src/features/common/components/BackButton'
 import { Links } from 'src/features/common/components/Links'
+import Modal from 'src/features/common/components/Modal'
 import {
   fetchArticles,
   fetchAuthorByUsername,
@@ -57,36 +53,25 @@ export default async function AuthorPage({
   const t = await getDictionary(pageLocale)
 
   return (
-    <AuthorDetail
-      author={currentAuthorTranslation}
-      articles={
-        <Links
-          header={t('author.PublishedArticles')}
-          items={authorArticlesTranslations.map(getArticleLinkParams)}
-        />
-      }
-      alternatives={
-        <Links
-          header={t('common.NotYourLanguage?')}
-          items={allAuthorTranslations.map(getAuthorLinkParams)}
-        />
-      }
-    />
+    <Modal>
+      <AuthorDetail
+        author={currentAuthorTranslation}
+        articles={
+          <Links
+            header={t('author.PublishedArticles')}
+            items={authorArticlesTranslations.map(getArticleLinkParams)}
+          />
+        }
+        alternatives={
+          <Links
+            header={t('common.NotYourLanguage?')}
+            items={allAuthorTranslations.map(getAuthorLinkParams)}
+          />
+        }
+        buttonBack={<BackButton>{t('author.BtnHome')}</BackButton>}
+      />
+    </Modal>
   )
-}
-
-export async function generateMetadata({
-  pageHref,
-  params,
-}: GenerateMetadataProps<AuthorParams>): Promise<Metadata> {
-  const pageLocale = router.getLocaleFromHref(pageHref)
-  const author = await fetchAuthorByUsername(params.author)
-
-  if (!author) {
-    return {}
-  }
-
-  return getAuthorMetadata(author, pageLocale)
 }
 
 export async function generateStaticParams({

--- a/example/src/routes/@modal/(.)blogs/i18n.js
+++ b/example/src/routes/@modal/(.)blogs/i18n.js
@@ -1,0 +1,5 @@
+module.exports.routeNames = [
+  { locale: 'en', path: '(.)blogs' },
+  { locale: 'cs', path: '(.)blogy' },
+  { locale: 'es', path: '(.)blogs' },
+]

--- a/example/src/routes/@modal/default.tsx
+++ b/example/src/routes/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/example/src/routes/blogs/[author]/[article]/page.tsx
+++ b/example/src/routes/blogs/[author]/[article]/page.tsx
@@ -4,6 +4,7 @@ import type {
   GenerateStaticParamsProps,
   PageProps,
 } from 'next-roots'
+import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import { ArticleDetail } from 'src/features/blog/components/ArticleDetail'
 import { getArticleLinkParams } from 'src/features/blog/utils/getArticleLinkParams'
@@ -14,7 +15,7 @@ import {
 } from 'src/features/blog/utils/getArticleTranslation'
 import { Links } from 'src/features/common/components/Links'
 import { fetchArticleBySlug, fetchArticles, fetchAuthors } from 'src/server/db'
-import { getArticleHref, router } from 'src/server/router'
+import { getArticleHref, getHomeHref, router } from 'src/server/router'
 import { getDictionary } from 'src/server/utils/getDictionary'
 
 type AuthorArticleParams = { author: string; article: string }
@@ -56,6 +57,15 @@ export default async function AuthorArticlePage({
           header={t('common.NotYourLanguage?')}
           items={allArticleTranslations.map(getArticleLinkParams)}
         />
+      }
+      buttonBack={
+        <Link
+          href={getHomeHref(currentArticleTranslation.locale)}
+          role="button"
+          className="rounded bg-indigo-600 px-4 py-2 text-base font-semibold leading-7 text-white"
+        >
+          {t('article.BtnBack')}
+        </Link>
       }
     />
   )

--- a/example/src/routes/blogs/[author]/page.tsx
+++ b/example/src/routes/blogs/[author]/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from 'next'
+import type {
+  GenerateMetadataProps,
+  GenerateStaticParamsProps,
+  PageProps,
+} from 'next-roots'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { AuthorDetail } from 'src/features/blog/components/AuthorDetail'
+import { getArticleLinkParams } from 'src/features/blog/utils/getArticleLinkParams'
+import { getArticleTranslationFactory } from 'src/features/blog/utils/getArticleTranslation'
+import { getAuthorLinkParams } from 'src/features/blog/utils/getAuthorLinkParams'
+import { getAuthorMetadata } from 'src/features/blog/utils/getAuthorMetadata'
+import {
+  getAllAuthorTranslations,
+  getAuthorTranslation,
+} from 'src/features/blog/utils/getAuthorTranslation'
+import { Links } from 'src/features/common/components/Links'
+import {
+  fetchArticles,
+  fetchAuthorByUsername,
+  fetchAuthors,
+} from 'src/server/db'
+import { getHomeHref, router } from 'src/server/router'
+import { getDictionary } from 'src/server/utils/getDictionary'
+
+type AuthorParams = { author: string }
+
+export default async function AuthorPage({
+  params,
+  pageHref,
+}: PageProps<AuthorParams>) {
+  const pageLocale = router.getLocaleFromHref(pageHref)
+  const author = await fetchAuthorByUsername(params.author)
+
+  if (!author) {
+    return notFound()
+  }
+
+  const allAuthorTranslations = getAllAuthorTranslations(author)
+  const currentAuthorTranslation = getAuthorTranslation({
+    author,
+    locale: pageLocale,
+  })
+
+  if (!currentAuthorTranslation) {
+    return notFound()
+  }
+
+  const articles = await fetchArticles()
+  const authorArticles = articles.filter(
+    ({ authorId }) => authorId === author.id
+  )
+
+  const getArticleTranslation = getArticleTranslationFactory(pageLocale)
+  const authorArticlesTranslations = authorArticles.map(getArticleTranslation)
+
+  const t = await getDictionary(pageLocale)
+
+  return (
+    <AuthorDetail
+      author={currentAuthorTranslation}
+      articles={
+        <Links
+          header={t('author.PublishedArticles')}
+          items={authorArticlesTranslations.map(getArticleLinkParams)}
+        />
+      }
+      alternatives={
+        <Links
+          header={t('common.NotYourLanguage?')}
+          items={allAuthorTranslations.map(getAuthorLinkParams)}
+        />
+      }
+      buttonBack={
+        <Link
+          href={getHomeHref(currentAuthorTranslation.locale)}
+          role="button"
+          className="rounded bg-indigo-600 px-4 py-2 text-base font-semibold leading-7 text-white"
+        >
+          {t('author.BtnHome')}
+        </Link>
+      }
+    />
+  )
+}
+
+export async function generateMetadata({
+  pageHref,
+  params,
+}: GenerateMetadataProps<AuthorParams>): Promise<Metadata> {
+  const pageLocale = router.getLocaleFromHref(pageHref)
+  const author = await fetchAuthorByUsername(params.author)
+
+  if (!author) {
+    return {}
+  }
+
+  return getAuthorMetadata(author, pageLocale)
+}
+
+export async function generateStaticParams({
+  pageLocale,
+}: GenerateStaticParamsProps) {
+  const authors = await fetchAuthors()
+  return authors.map((a) => ({
+    author: a.username,
+  }))
+}

--- a/example/src/routes/blogs/i18n.js
+++ b/example/src/routes/blogs/i18n.js
@@ -1,0 +1,5 @@
+module.exports.routeNames = [
+  { locale: 'en', path: 'blogs' },
+  { locale: 'cs', path: 'blogy' },
+  { locale: 'es', path: 'blogs' },
+]

--- a/example/src/server/router/index.ts
+++ b/example/src/server/router/index.ts
@@ -13,7 +13,7 @@ export function getPageLocale() {
 }
 
 export function getArticleHref(article: ArticleTranslation) {
-  return router.getHref('/[author]/[article]', {
+  return router.getHref('/blogs/[author]/[article]', {
     article: article.slug,
     author: article.author?.username || '#',
     locale: article.locale || getPageLocale(),
@@ -21,7 +21,7 @@ export function getArticleHref(article: ArticleTranslation) {
 }
 
 export function getAuthorHref(author: AuthorTranslation) {
-  return router.getHref('/[author]', {
+  return router.getHref('/blogs/[author]', {
     author: author.username,
     locale: author.locale || getPageLocale(),
   })


### PR DESCRIPTION
In this PR are the updates for the example app. I implemented a Modal with the parallel and intercepting routes functionalities.

This PR requires a new version 3.1.0 of next-roots that has support for paraller and intercepting routes.