### PR TITLE
add middleware

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -4,6 +4,7 @@ import { generateFactory } from './commands/generate'
 import {
   DEFAULT_LOCALIZE_DIR,
   DEFAULT_ORIGIN_DIR,
+  DEFAULT_ROOT_ALIAS,
   getConfig,
   PKG_NAME,
 } from './config'
@@ -19,6 +20,7 @@ const cliDefaultParams: CliParams = {
   locales: [],
   prefixDefaultLocale: true,
   packageDir: path.join(process.cwd(), `node_modules/${PKG_NAME}`),
+  rootAlias: DEFAULT_ROOT_ALIAS,
 }
 
 const cliFileParams = require(path.join(process.cwd(), configPath))

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -6,6 +6,8 @@ import { ConfigError } from './errors'
 export const PKG_NAME = 'next-roots'
 export const DEFAULT_ORIGIN_DIR = './roots'
 export const DEFAULT_LOCALIZE_DIR = './app'
+export const DEFAULT_ROOT_DIR = './app'
+export const DEFAULT_ROOT_ALIAS = './app'
 
 function getPathFactory(dirName: string) {
   return (fileName = '') => path.join(dirName, fileName)
@@ -37,6 +39,8 @@ export function getConfig(cliParams: CliParams): Config {
     )
   }
 
+  const getRootAliasPath = getPathFactory(cliParams.rootAlias)
+
   const getDistAbsolutePath = getPathFactory(distRoot)
   const getCacheAbsolutePath = getPathFactory(path.join(distRoot, 'cache'))
 
@@ -59,5 +63,6 @@ export function getConfig(cliParams: CliParams): Config {
     getDistAbsolutePath,
     getCacheAbsolutePath,
     getOriginContents,
+    getRootAliasPath,
   })
 }

--- a/src/cli/generators/generateLocalizedFiles.ts
+++ b/src/cli/generators/generateLocalizedFiles.ts
@@ -1,5 +1,6 @@
 import { copyFile, removeDir, writeFile } from '~/utils/fs-utils'
 import { compileFactory as compileLayoutFactory } from '../templates/layout-tpl'
+import { compileFactory as compileMiddlewareFactory } from '../templates/middleware-tpl'
 import { compileFactory as compileNotFoundFactory } from '../templates/not-found-tpl'
 import { compileFactory as compilePageFactory } from '../templates/page-tpl'
 import type { Config, Rewrite } from '../types'
@@ -10,6 +11,10 @@ function isPage(pathName: string) {
 
 function isLayout(pathName: string) {
   return pathName.match(/layout\.([tj]sx)?$/)
+}
+
+function isMiddleware(pathName: string) {
+  return pathName.match(/_middleware\.([tj]s)?$/)
 }
 
 function isNotFound(pathName: string) {
@@ -28,6 +33,10 @@ function getCompilerFactory(config: Config) {
 
     if (isNotFound(originPath)) {
       return compileNotFoundFactory(config)
+    }
+
+    if (isMiddleware(originPath)) {
+      return compileMiddlewareFactory(config)
     }
 
     return undefined

--- a/src/cli/generators/generateMiddlewareFileFactory.ts
+++ b/src/cli/generators/generateMiddlewareFileFactory.ts
@@ -1,0 +1,15 @@
+import type { Middleware } from '~/types'
+import { writeFile } from '~/utils/fs-utils'
+import { compile } from '../templates/lib-middleware-file-tpl'
+import type { Config } from '../types'
+
+export function generateMiddlewareFileFactory({
+  getLocalizedAbsolutePath,
+}: Config) {
+  return (middlewares: Middleware[]) => {
+    const to = getLocalizedAbsolutePath('_middleware.ts')
+    const content = compile(middlewares)
+
+    writeFile(to, content)
+  }
+}

--- a/src/cli/templates/layout-tpl.test.ts
+++ b/src/cli/templates/layout-tpl.test.ts
@@ -11,6 +11,7 @@ const defaultConfig: Config = {
   getLocalizedAbsolutePath: () => '',
   getOriginAbsolutePath: () => '',
   getOriginContents: () => '',
+  getRootAliasPath: () => '',
 }
 
 test('should create root layout', () => {

--- a/src/cli/templates/lib-middleware-file-tpl.ts
+++ b/src/cli/templates/lib-middleware-file-tpl.ts
@@ -1,0 +1,107 @@
+import type { Middleware } from '~/types'
+import type { CompileParams } from './tpl-utils'
+import { compileTemplateFactory, getPatternsFromNames } from './tpl-utils'
+
+export const PATTERNS = getPatternsFromNames(
+  'schema',
+  'imports',
+  'middleware_map'
+)
+
+export const tpl = `
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+${PATTERNS.imports}
+
+export type Middleware = {
+  href: string
+  path: string
+  originName: string
+}
+
+const schema: Middleware[] = ${PATTERNS.schema};
+
+const getMiddleware = (name: string) => {
+  switch (name) {
+    ${PATTERNS.middleware_map}
+    default:
+      return;
+  }
+};
+
+const getMiddlewares = (pathname: string) => {
+  const _middlewares: Middleware[] = [];
+  for (const _middleware of schema) {
+      if (_middleware.href === pathname) _middlewares.push(_middleware);
+  }
+  const segments = pathname.split('/');
+  for (let i = segments.length - 1; i > 0; i--) {
+      const href = segments.slice(0, i).join('/');
+      for (const _middleware of schema) {
+          if (_middleware.href === href) _middlewares.push(_middleware);
+      }
+  }
+  return _middlewares;
+};
+
+
+
+export async function middleware(
+  request: NextRequest,
+  response: NextResponse,
+): Promise<NextResponse> {
+  let _response = response;
+  const middlewares = getMiddlewares(request.nextUrl.pathname);
+  if (middlewares.length <= 0) return _response;
+  middlewares.reverse();
+  for (const _middleware of middlewares) {
+      if (!_middleware) continue;
+      try {
+          const middlewareNext = getMiddleware(_middleware.originName);
+          if (!middlewareNext) continue;
+          let responseNext = await middlewareNext(request, _response);
+          if (
+              'headers' in responseNext &&
+              'location' in responseNext.headers
+          ) {
+              return responseNext;
+          }
+          _response = responseNext;
+      } catch (error) {
+          console.log('error', error);
+      }
+      // if (response) return response;
+  }
+  return _response;
+}
+
+
+`
+
+function getCompileParams(
+  middlewares: Middleware[]
+): CompileParams<typeof PATTERNS> {
+  const imports: Record<string, string> = {}
+  for (const _middleware of middlewares) {
+    if (_middleware.originName in imports) continue
+    imports[_middleware.originName] = _middleware.path
+  }
+
+  return {
+    schema: JSON.stringify(middlewares),
+    imports: Object.keys(imports)
+      .map((name) => `import ${name} from '${imports[name]}'`)
+      .join('\n'),
+    middleware_map: Object.keys(imports)
+      .map((name) => `case '${name}': return ${name}`)
+      .join('\n'),
+  }
+}
+
+export function compile(middlewares: Middleware[]) {
+  const params = getCompileParams(middlewares)
+
+  const compileTemplate = compileTemplateFactory()
+  return compileTemplate(tpl, params)
+}

--- a/src/cli/templates/middleware-tpl.ts
+++ b/src/cli/templates/middleware-tpl.ts
@@ -1,0 +1,53 @@
+import { getLocaleFactory } from '~/utils/locale-utils'
+import type { Config, Rewrite } from '../types'
+import type { CompileParams } from './tpl-utils'
+import {
+  compileTemplateFactory,
+  getOriginNameFactory,
+  getOriginPathFactory,
+  getPatternsFromNames,
+} from './tpl-utils'
+
+export const PATTERNS = getPatternsFromNames(
+  'originName',
+  'originPath',
+  'locale'
+)
+
+export const tpl = `
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { middleware as ${PATTERNS.originName}Origin } from '${PATTERNS.originPath}'
+
+export default function ${PATTERNS.originName}(request: NextRequest, response: NextResponse): Promise<NextResponse> {
+  return ${PATTERNS.originName}Origin(request, response, "${PATTERNS.locale}");
+}
+`
+
+function getCompileParams(config: Config) {
+  return (rewrite: Rewrite): CompileParams<typeof PATTERNS> => {
+    const getOriginPath = getOriginPathFactory(config)
+    const getOriginName = getOriginNameFactory('not-found')
+    const getLocale = getLocaleFactory({
+      defaultLocale: config.defaultLocale,
+      locales: config.locales,
+    })
+
+    return {
+      originPath: getOriginPath(rewrite),
+      originName: getOriginName(rewrite),
+      locale: getLocale(rewrite.localizedPath),
+    }
+  }
+}
+
+export function compileFactory(config: Config) {
+  const getParams = getCompileParams(config)
+  return (rewrite: Rewrite) => {
+    const params = getParams(rewrite)
+
+    const compileTemplate = compileTemplateFactory()
+
+    return compileTemplate(tpl, params)
+  }
+}

--- a/src/cli/templates/not-found-tpl.test.ts
+++ b/src/cli/templates/not-found-tpl.test.ts
@@ -11,6 +11,7 @@ const defaultConfig: Config = {
   getLocalizedAbsolutePath: () => '',
   getOriginAbsolutePath: () => '',
   getOriginContents: () => '',
+  getRootAliasPath: () => '',
 }
 
 test('should create root not-found', () => {

--- a/src/cli/templates/page-tpl.test.ts
+++ b/src/cli/templates/page-tpl.test.ts
@@ -11,6 +11,7 @@ const defaultConfig: Config = {
   getLocalizedAbsolutePath: () => '',
   getOriginAbsolutePath: () => '',
   getOriginContents: () => '',
+  getRootAliasPath: () => '',
 }
 
 test('should create root page', () => {

--- a/src/cli/templates/template-tpl.test.ts
+++ b/src/cli/templates/template-tpl.test.ts
@@ -11,6 +11,7 @@ const defaultConfig: Config = {
   getLocalizedAbsolutePath: () => '',
   getOriginAbsolutePath: () => '',
   getOriginContents: () => '',
+  getRootAliasPath: () => '',
 }
 
 test('should create root template', () => {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -5,6 +5,7 @@ export type CliParams = {
   defaultLocale: string
   prefixDefaultLocale: boolean
   packageDir: string
+  rootAlias: string
 }
 
 export type Config = {
@@ -16,6 +17,7 @@ export type Config = {
   getDistAbsolutePath: (fileName?: string) => string
   getCacheAbsolutePath: (fileName?: string) => string
   getOriginContents: (fileName: string) => string
+  getRootAliasPath: (fileName?: string) => string
 }
 
 export type Origin = {

--- a/src/cli/utils/getMiddleware.test.ts
+++ b/src/cli/utils/getMiddleware.test.ts
@@ -1,0 +1,118 @@
+import path from 'path'
+import type { Middleware } from '~/types'
+import type { Config, Rewrite } from '../types'
+import { getMiddleware, isMiddleware } from './getMiddleware'
+
+const defaultConfig: Config = {
+  defaultLocale: 'lt',
+  locales: ['lt', 'en'],
+  prefixDefaultLocale: true,
+  getCacheAbsolutePath: () => '',
+  getDistAbsolutePath: () => '',
+  getLocalizedAbsolutePath: () => '',
+  getOriginAbsolutePath: () => '',
+  getOriginContents: () => '',
+  getRootAliasPath: () => '',
+}
+
+const inputConfig = {
+  ...defaultConfig,
+  getRootAliasPath: (fileName = '') => path.join('/Root/app', fileName),
+}
+
+const inputRewrites: Rewrite[] = [
+  {
+    originPath: '/(auth)/_middleware.ts',
+    localizedPath: '/en/(auth)/_middleware.ts',
+  },
+  {
+    originPath: '/(auth)/login/_middleware.ts',
+    localizedPath: '/en/(auth)/log-in/_middleware.ts',
+  },
+  {
+    originPath: '/@header/login/_middleware.tsx',
+    localizedPath: '/en/@header/log-in/_middleware.tsx',
+  },
+  {
+    originPath: '/blog/[authorId]/[articleId]/_middleware.ts',
+    localizedPath: '/en/blog/[authorId]/[articleId]/_middleware.ts',
+  },
+  {
+    originPath: '/@modal/(.)blog/[authorId]/[articleId]/_middleware.ts',
+    localizedPath: '/en/@modal/(.)blog/[authorId]/[articleId]/_middleware.ts',
+  },
+  {
+    originPath: '/feed/@modal/(..)blog/[authorId]/[articleId]/_middleware.ts',
+    localizedPath:
+      '/en/feed/@modal/(..)blog/[authorId]/[articleId]/_middleware.ts',
+  },
+  {
+    originPath:
+      '/feed/friends/@modal/(..)(..)blog/[authorId]/[articleId]/_middleware.ts',
+    localizedPath:
+      '/en/feed/friends/@modal/(..)(..)blog/[authorId]/[articleId]/_middleware.ts',
+  },
+  {
+    originPath:
+      '/feed/friends/@modal/(...)blog/[authorId]/[articleId]/_middleware.ts',
+    localizedPath:
+      '/en/feed/friends/@modal/(...)blog/[authorId]/[articleId]/_middleware.ts',
+  },
+]
+
+const expectedSchema: Array<Middleware | undefined> = [
+  {
+    href: '/en',
+    path: '/Root/app/en/(auth)/_middleware.ts',
+    originName: 'AuthMiddleware',
+  },
+  {
+    href: '/en/log-in',
+    path: '/Root/app/en/(auth)/log-in/_middleware.ts',
+    originName: 'AuthLoginMiddleware',
+  },
+  undefined,
+  {
+    href: '/en/blog/:authorId/:articleId',
+    path: '/Root/app/en/blog/[authorId]/[articleId]/_middleware.ts',
+    originName: 'BlogAuthorIdArticleIdMiddleware',
+  },
+  {
+    href: '/en/blog/:authorId/:articleId',
+    path: '/Root/app/en/@modal/(.)blog/[authorId]/[articleId]/_middleware.ts',
+    originName: 'ModalAuthorIdArticleIdMiddleware',
+  },
+  {
+    href: '/en/blog/:authorId/:articleId',
+    path: '/Root/app/en/feed/@modal/(..)blog/[authorId]/[articleId]/_middleware.ts',
+    originName: 'FeedModalAuthorIdArticleIdMiddleware',
+  },
+  {
+    href: '/en/blog/:authorId/:articleId',
+    path: '/Root/app/en/feed/friends/@modal/(..)(..)blog/[authorId]/[articleId]/_middleware.ts',
+    originName: 'FeedFriendsModalAuthorIdArticleIdMiddleware',
+  },
+  {
+    href: '/en/blog/:authorId/:articleId',
+    path: '/Root/app/en/feed/friends/@modal/(...)blog/[authorId]/[articleId]/_middleware.ts',
+    originName: 'FeedFriendsModalAuthorIdArticleIdMiddleware',
+  },
+]
+
+test('getMiddleware', () => {
+  const routes = inputRewrites.map(getMiddleware(inputConfig))
+  expect(routes).toEqual(expectedSchema)
+})
+
+describe('isMiddleware', () => {
+  const testCases = [
+    [{}, false],
+    [{ path: '' }, false],
+    [{ href: '' }, false],
+    [{ path: '', href: '' }, true],
+  ] as const
+
+  test.each(testCases)('given %o, returns %s', (input, expectedResult) => {
+    expect(isMiddleware(input)).toEqual(expectedResult)
+  })
+})

--- a/src/cli/utils/getMiddleware.ts
+++ b/src/cli/utils/getMiddleware.ts
@@ -1,0 +1,38 @@
+import type { Middleware } from '~/types'
+import { getOriginNameFactory } from '../templates/tpl-utils'
+import type { Config, Rewrite } from '../types'
+import { getRouteHref } from './getRoute'
+
+function getMiddlewareHref(rewrite: Rewrite) {
+  const routeHref = getRouteHref(rewrite)
+  // remove everything after the last slash
+  return routeHref.replace(/\/[^/]+$/, '')
+}
+
+function isMiddlewareRewrite({ originPath }: Rewrite): boolean {
+  return (
+    Boolean(originPath.match(/\/_middleware\.([tj])s?$/)) || originPath === '/'
+  )
+}
+
+export function isMiddleware(input: unknown): input is Middleware {
+  return Boolean(
+    input && typeof input === 'object' && 'path' in input && 'href' in input
+  )
+}
+
+export function getMiddleware(config: Config) {
+  const { getRootAliasPath } = config
+  return (rewrite: Rewrite): Middleware | undefined => {
+    if (isMiddlewareRewrite(rewrite)) {
+      const getOriginName = getOriginNameFactory('middleware')
+      return {
+        href: getMiddlewareHref(rewrite),
+        path: getRootAliasPath(rewrite.localizedPath),
+        originName: getOriginName(rewrite),
+      }
+    }
+
+    return undefined
+  }
+}

--- a/src/cli/utils/getRoute.ts
+++ b/src/cli/utils/getRoute.ts
@@ -37,7 +37,7 @@ function formatDynamicSegments(input: string) {
   return input.replace(/\/\[(\w+)\]/g, '/:$1')
 }
 
-function getRouteName({ originPath }: Rewrite) {
+export function getRouteName({ originPath }: Rewrite) {
   const formatRouteName = pipe(
     removePageSegment,
     removeGroupSegments,
@@ -47,7 +47,7 @@ function getRouteName({ originPath }: Rewrite) {
   return asRootPath(formatRouteName(originPath))
 }
 
-function getRouteHref({ localizedPath }: Rewrite) {
+export function getRouteHref({ localizedPath }: Rewrite) {
   const localeSegment = extractLocaleSegment(localizedPath)
   const formatRouteHref = pipe(
     removeLocaleSegment,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,9 @@ export type RouterSchema = {
   locales: string[]
   defaultLocale: string
 }
+
+export type Middleware = {
+  href: string
+  path: string
+  originName: string
+}


### PR DESCRIPTION
This is concept for middleware using with next-roots with next.js 13 app routing. 

I am focused into typescript, so it's kinda write for it (example: middleware.ts) but not everything is typed. It's need more work to finish it. In our project it's fit, so i am done with this for now. I am publishing for others to use it and improve.

It's very good for workaround in next.js 13 new middleware, then for now it's not possible to use multiple middlewares. 

You can create in nested files _middleware.ts file with content: 
```
import { NextResponse } from 'next/server';
import type { NextRequest } from 'next/server';

// this middleware is handling auth, non-authed users will be redirected to login page

// This function can be marked `async` if using `await` inside
export async function middleware(request: NextRequest, response: NextResponse, locale: string): Promise<NextResponse> {
    console.log('middleware auth')
    return response;
}
```
and by logic it's will called in reverse order by path.

example:
dashobard/_middleware.ts (handling auth middleware)
dashboard/services/[xxxx]/_middleware.ts (handling service ownership)

first called second and then will call first middleware.

You must create in root (example src/) folder `middleware.ts` file and in that file call this middleware logic:
```
import { middleware as middlewareRoots } from '@app/(routes)/_middleware';
....
export async function middleware(request: NextRequest) {
....

    return middlewareRoots(request, response);
}
```

*EDIT*

Because i using typescript and want to path alias use i add new config variable (roots.config.js): 
```
module.exports = {
...
    rootAlias: '@app/(routes)'
...
};
```

P.S. Sorry for bad english and explain.. If it's helped press like and don't forget mention me in contribution 