### PR TITLE
Fix: Resolve Argument Count Mismatch Error in generateMetadata Function Usage

### DIFF
--- a/src/cli/templates/decorators/with-layout-metadata.ts
+++ b/src/cli/templates/decorators/with-layout-metadata.ts
@@ -1,7 +1,11 @@
 import type { Rewrite } from '~/cli/types'
 import { isTypedRewrite } from '~/utils/rewrite-utils'
-import type { CompileFn, DecoratorParams } from '../tpl-utils'
-import { getPattern, removePropTypes } from '../tpl-utils'
+import {
+  getPattern,
+  removePropTypes,
+  type CompileFn,
+  type DecoratorParams,
+} from '../tpl-utils'
 
 export const PATTERNS = {
   originPath: getPattern('originPath'),
@@ -16,6 +20,7 @@ export const tplDynamic = `
 import {generateMetadata as generateMetadataOrigin} from '${PATTERNS.originPath}'
 
 export async function generateMetadata(props:any) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...props, locale: "${PATTERNS.locale}" })
 }
 `

--- a/src/cli/templates/decorators/with-page-metadata.ts
+++ b/src/cli/templates/decorators/with-page-metadata.ts
@@ -1,7 +1,11 @@
 import type { Rewrite } from '~/cli/types'
 import { isDynamicRewrite, isTypedRewrite } from '~/utils/rewrite-utils'
-import type { DecoratorParams, CompileFn } from '../tpl-utils'
-import { getPattern, removePropTypes } from '../tpl-utils'
+import {
+  getPattern,
+  removePropTypes,
+  type DecoratorParams,
+  type CompileFn,
+} from '../tpl-utils'
 
 export const PATTERNS = {
   originPath: getPattern('originPath'),
@@ -16,6 +20,7 @@ export const tplDynamicForStaticRoute = `
 import {generateMetadata as generateMetadataOrigin} from '${PATTERNS.originPath}'
 
 export async function generateMetadata(props:any) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...props, pageHref: "${PATTERNS.pageHref}" })
 }
 `
@@ -24,6 +29,7 @@ export const tplDynamicForDynamicRoute = `
 import {generateMetadata as generateMetadataOrigin} from '${PATTERNS.originPath}'
 
 export async function generateMetadata({ params, ...otherProps }:any) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...otherProps, params, pageHref: compileHref('${PATTERNS.pageHref}', params) })
 }
 `

--- a/src/cli/templates/layout-tpl.test.ts
+++ b/src/cli/templates/layout-tpl.test.ts
@@ -148,6 +148,7 @@ export default function DynamicMetaDataLayout(props) {
 import {generateMetadata as generateMetadataOrigin} from '..'
 
 export async function generateMetadata(props) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...props, locale: "cs" })
 }
 `

--- a/src/cli/templates/page-tpl.test.ts
+++ b/src/cli/templates/page-tpl.test.ts
@@ -177,6 +177,7 @@ export default function StaticRouteWithDynamicMetaDataPage(props) {
 import {generateMetadata as generateMetadataOrigin} from '..'
 
 export async function generateMetadata(props) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...props, pageHref: "/cs/static-route-with-dynamic-meta-data" })
 }
 `
@@ -209,6 +210,7 @@ export default function BlogAuthorIdPage({ params, ...otherProps }:any) {
 import {generateMetadata as generateMetadataOrigin} from '../../../../../roots/blog/[authorId]/page'
 
 export async function generateMetadata({ params, ...otherProps }:any) {
+  {/* @ts-ignore */}
   return generateMetadataOrigin({ ...otherProps, params, pageHref: compileHref('/cs/magazin/:authorId', params) })
 }
 


### PR DESCRIPTION
Hi svobik7, thanks for this awesome package.

Encountered an issue with `generateMetadata` function when trying to localize the metadata for different pages and layouts. During the build process, TypeScript throws an error due to an unexpected argument being passed to `generateMetadataOrigin` function.

Error:
```
 ✓ Compiled successfully
   Linting and checking validity of types  .Failed to compile.

./app/(routes)/(en)/get-started/page.tsx:14:33
Type error: Expected 0 arguments, but got 1.

  12 |
  13 | export async function generateMetadata(props:any) {
> 14 |   return generateMetadataOrigin({ ...props, pageHref: "/get-started" })
     |                                 ^
  15 | }
  16 |
error Command failed with exit code 1.
  ```

Added `// @ts-ignore` above generateMetadataOrigin to prevent this error being fired. If I'm not mistaken is the same way is/was fixed in the export of the LayoutOrigin and PageOrigin components, not sure if it's still necessary there, just removed the `ts-ignore` and it didn't complain but didn't want to modify it since haven't fully checked all the code and might be something I'm missing.

```
{/* @ts-ignore */}
return generateMetadataOrigin({ ...props, pageHref: "/get-started" })
```

Let me know if there's any better way to solve it. Thanks in advance.