### PR TITLE
feat(templates): include generateStaticParams in Generated layout.tsx

### DIFF
--- a/src/cli/templates/decorators/with-layout-generate-static-params.ts
+++ b/src/cli/templates/decorators/with-layout-generate-static-params.ts
@@ -1,0 +1,32 @@
+import { getPattern ,type  CompileFn,type  DecoratorParams  } from '../tpl-utils';
+
+export const PATTERNS = {
+  originPath: getPattern('originPath'),
+  locale: getPattern('locale'),
+}
+
+export const tpl = `
+import {generateStaticParams as generateStaticParamsOrigin} from '${PATTERNS.originPath}'
+
+export async function generateStaticParams() {
+  return generateStaticParamsOrigin({ locale: "${PATTERNS.locale}" })
+}
+`
+
+export function withLayoutGenerateStaticParams(input: string) {
+  return `${input}${tpl}`
+}
+
+export function withLayoutGenerateStaticParamsFactory(
+  params: DecoratorParams
+): CompileFn {
+  if (
+    params
+      .getOriginContents()
+      .match(/export async function generateStaticParams/g)
+  ) {
+    return withLayoutGenerateStaticParams
+  }
+
+  return (i: string) => i
+}

--- a/src/cli/templates/layout-tpl.test.ts
+++ b/src/cli/templates/layout-tpl.test.ts
@@ -166,19 +166,13 @@ export async function generateMetadata(props) {
   expect(output).toBe(expectedOutput)
 })
 
-test('should create layout with dynamic metadata object and generate static params', () => {
+test('should create layout with generate static params', () => {
   const expectedOutput = `
-import DynamicMetaDataLayoutOrigin from '..'
+import GenerateStaticParamsLayoutOrigin from '..'
 
-export default function DynamicMetaDataLayout(props) {
+export default function GenerateStaticParamsLayout(props) {
   {/* @ts-ignore */}
-  return <DynamicMetaDataLayoutOrigin {...props} locale="cs" />
-}
-
-import {generateMetadata as generateMetadataOrigin} from '..'
-
-export async function generateMetadata(props) {
-  return generateMetadataOrigin({ ...props, locale: "cs" })
+  return <GenerateStaticParamsLayoutOrigin {...props} locale="cs" />
 }
 
 import {generateStaticParams as generateStaticParamsOrigin} from '..'
@@ -188,14 +182,13 @@ export async function generateStaticParams() {
 }
 `
   const inputRewrite = {
-    originPath: '/dynamic-meta-data/layout.js',
-    localizedPath: '/cs/dynamic-meta-data/layout.js',
+    originPath: '/generate-static-params/layout.js',
+    localizedPath: '/cs/generate-static-params/layout.js',
   }
 
   const inputConfig: Config = {
     ...defaultConfig,
-    getOriginContents: () =>
-      `export async function generateMetadata() {};export async function generateStaticParams() {}`,
+    getOriginContents: () => `export async function generateStaticParams() {}`,
   }
 
   const compile = compileFactory(inputConfig)

--- a/src/cli/templates/layout-tpl.test.ts
+++ b/src/cli/templates/layout-tpl.test.ts
@@ -165,3 +165,40 @@ export async function generateMetadata(props) {
   const output = compile(inputRewrite)
   expect(output).toBe(expectedOutput)
 })
+
+test('should create layout with dynamic metadata object and generate static params', () => {
+  const expectedOutput = `
+import DynamicMetaDataLayoutOrigin from '..'
+
+export default function DynamicMetaDataLayout(props) {
+  {/* @ts-ignore */}
+  return <DynamicMetaDataLayoutOrigin {...props} locale="cs" />
+}
+
+import {generateMetadata as generateMetadataOrigin} from '..'
+
+export async function generateMetadata(props) {
+  return generateMetadataOrigin({ ...props, locale: "cs" })
+}
+
+import {generateStaticParams as generateStaticParamsOrigin} from '..'
+
+export async function generateStaticParams() {
+  return generateStaticParamsOrigin({ locale: "cs" })
+}
+`
+  const inputRewrite = {
+    originPath: '/dynamic-meta-data/layout.js',
+    localizedPath: '/cs/dynamic-meta-data/layout.js',
+  }
+
+  const inputConfig: Config = {
+    ...defaultConfig,
+    getOriginContents: () =>
+      `export async function generateMetadata() {};export async function generateStaticParams() {}`,
+  }
+
+  const compile = compileFactory(inputConfig)
+  const output = compile(inputRewrite)
+  expect(output).toBe(expectedOutput)
+})

--- a/src/cli/templates/layout-tpl.ts
+++ b/src/cli/templates/layout-tpl.ts
@@ -8,11 +8,11 @@ import {
   type CompileParams,
   DecoratorParams,
   removePropTypes,
-
   compileTemplateFactory,
   getOriginNameFactory,
   getOriginPathFactory,
-  getPatternsFromNames} from './tpl-utils'
+  getPatternsFromNames,
+} from './tpl-utils'
 
 export const PATTERNS = getPatternsFromNames(
   'originName',

--- a/src/cli/templates/layout-tpl.ts
+++ b/src/cli/templates/layout-tpl.ts
@@ -2,18 +2,17 @@ import { getLocaleFactory } from '~/utils/locale-utils'
 import { isTypedRewrite } from '~/utils/rewrite-utils'
 import type { Config, Rewrite } from '../types'
 import { withLayoutMetadataDecoratorFactory } from './decorators/with-layout-metadata'
+import { withLayoutGenerateStaticParamsFactory } from './decorators/with-layout-generate-static-params'
 import { withRouteSegmentConfigFactory } from './decorators/with-route-segment-config'
 import {
   type CompileParams,
   DecoratorParams,
   removePropTypes,
-} from './tpl-utils'
-import {
+
   compileTemplateFactory,
   getOriginNameFactory,
   getOriginPathFactory,
-  getPatternsFromNames,
-} from './tpl-utils'
+  getPatternsFromNames} from './tpl-utils'
 
 export const PATTERNS = getPatternsFromNames(
   'originName',
@@ -58,7 +57,8 @@ export function compileFactory(config: Config) {
 
     const compileTemplate = compileTemplateFactory(
       withRouteSegmentConfigFactory(decoratorParams),
-      withLayoutMetadataDecoratorFactory(decoratorParams)
+      withLayoutMetadataDecoratorFactory(decoratorParams),
+      withLayoutGenerateStaticParamsFactory(decoratorParams)
     )
 
     return compileTemplate(layoutTpl, params)

--- a/src/cli/templates/lib-declaration-tpl.test.ts
+++ b/src/cli/templates/lib-declaration-tpl.test.ts
@@ -106,7 +106,12 @@ export type PageProps<TParams = void> = TParams extends void
 export type LayoutProps<TParams = any> = { locale: string, params: TParams }
 export type GeneratePageMetadataProps<TParams = any> = { pageHref: string, params: TParams }
 export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, params: TParams }
+/**
+ * @deprecated Use GeneratePageStaticParamsProps instead
+ */
 export type GenerateStaticParamsProps = { pageLocale: string }
+export type GeneratePageStaticParamsProps = { pageLocale: string }
+export type GenerateLayoutStaticParamsProps = { locale: string }
 `
 
   test('should create lib declaration', () => {
@@ -177,7 +182,12 @@ export type PageProps<TParams = void> = TParams extends void
 export type LayoutProps<TParams = any> = { locale: string, params: TParams }
 export type GeneratePageMetadataProps<TParams = any> = { pageHref: string, params: TParams }
 export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, params: TParams }
+/**
+ * @deprecated Use GeneratePageStaticParamsProps instead
+ */
 export type GenerateStaticParamsProps = { pageLocale: string }
+export type GeneratePageStaticParamsProps = { pageLocale: string }
+export type GenerateLayoutStaticParamsProps = { locale: string }
 `
 
   test('should create lib declaration', () => {

--- a/src/cli/templates/lib-declaration-tpl.ts
+++ b/src/cli/templates/lib-declaration-tpl.ts
@@ -47,7 +47,12 @@ export type PageProps<TParams = void> = TParams extends void
 export type LayoutProps<TParams = any> = { locale: string, params: TParams }
 export type GeneratePageMetadataProps<TParams = any> = { pageHref: string, params: TParams }
 export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, params: TParams }
+/**
+ * @deprecated Use GeneratePageStaticParamsProps instead
+ */
 export type GenerateStaticParamsProps = { pageLocale: string }
+export type GeneratePageStaticParamsProps = { pageLocale: string }
+export type GenerateLayoutStaticParamsProps = { locale: string }
 `
 
 export const tplWithDynamicRoutes = `
@@ -87,7 +92,12 @@ export type PageProps<TParams = void> = TParams extends void
 export type LayoutProps<TParams = any> = { locale: string, params: TParams }
 export type GeneratePageMetadataProps<TParams = any> = { pageHref: string, params: TParams }
 export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, params: TParams }
+/**
+ * @deprecated Use GeneratePageStaticParamsProps instead
+ */
 export type GenerateStaticParamsProps = { pageLocale: string }
+export type GeneratePageStaticParamsProps = { pageLocale: string }
+export type GenerateLayoutStaticParamsProps = { locale: string }
 `
 
 function not<T>(fn: (input: T) => boolean) {


### PR DESCRIPTION
Include the `generateStaticParams` function from the original layout.tsx file in the generated
layout.tsx files.

fix https://github.com/svobik7/next-roots/issues/245