### PR TITLE
docs(readme): update missing devDependencies in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ The requirement is to have English localization served from `/` and Czech from `
 
 `yarn add next-roots`
 
-2. Add esbuild for compiling i18n config files to your project devDependencies
+2. Add esbuild and esbuild-node-externals for compiling i18n config files to your project devDependencies
 
-`yarn add --dev esbuild`
+`yarn add --dev esbuild esbuild-node-externals`
 
 2. (optional) Add generate script to your `package.json`
 


### PR DESCRIPTION
It seems that the release 3.8.0 now requires the user to install `esbuild-node-externals` as a dev dependency to be able to run the cli