### PR TITLE
feat(templates): support: passing params to `generateStaticParams`

### DIFF
--- a/src/cli/templates/decorators/with-layout-generate-static-params.ts
+++ b/src/cli/templates/decorators/with-layout-generate-static-params.ts
@@ -1,4 +1,4 @@
-import { getPattern ,type  CompileFn,type  DecoratorParams  } from '../tpl-utils';
+import { getPattern, type CompileFn, type DecoratorParams } from '../tpl-utils'
 
 export const PATTERNS = {
   originPath: getPattern('originPath'),
@@ -8,8 +8,8 @@ export const PATTERNS = {
 export const tpl = `
 import {generateStaticParams as generateStaticParamsOrigin} from '${PATTERNS.originPath}'
 
-export async function generateStaticParams() {
-  return generateStaticParamsOrigin({ locale: "${PATTERNS.locale}" })
+export async function generateStaticParams({ params, ...otherProps }:any) {
+  return generateStaticParamsOrigin({ ...otherProps, params, locale: "${PATTERNS.locale}" })
 }
 `
 

--- a/src/cli/templates/decorators/with-page-generate-static-params.ts
+++ b/src/cli/templates/decorators/with-page-generate-static-params.ts
@@ -1,5 +1,4 @@
-import type { CompileFn, DecoratorParams } from '../tpl-utils'
-import { getPattern } from '../tpl-utils'
+import { getPattern ,type  CompileFn,type  DecoratorParams  } from '../tpl-utils';
 
 export const PATTERNS = {
   originPath: getPattern('originPath'),
@@ -9,8 +8,8 @@ export const PATTERNS = {
 export const tpl = `
 import {generateStaticParams as generateStaticParamsOrigin} from '${PATTERNS.originPath}'
 
-export async function generateStaticParams() {
-  return generateStaticParamsOrigin({ pageLocale: "${PATTERNS.pageLocale}" })
+export async function generateStaticParams({ params, ...otherProps }:any) {
+  return generateStaticParamsOrigin({ ...otherProps, params, pageLocale: "${PATTERNS.pageLocale}" })
 }
 `
 
@@ -21,7 +20,11 @@ export function withPageGenerateStaticParams(input: string) {
 export function withPageGenerateStaticParamsFactory(
   params: DecoratorParams
 ): CompileFn {
-  if (params.getOriginContents().match(/export async function generateStaticParams/g)) {
+  if (
+    params
+      .getOriginContents()
+      .match(/export async function generateStaticParams/g)
+  ) {
     return withPageGenerateStaticParams
   }
 

--- a/src/cli/templates/layout-tpl.test.ts
+++ b/src/cli/templates/layout-tpl.test.ts
@@ -177,8 +177,8 @@ export default function GenerateStaticParamsLayout(props) {
 
 import {generateStaticParams as generateStaticParamsOrigin} from '..'
 
-export async function generateStaticParams() {
-  return generateStaticParamsOrigin({ locale: "cs" })
+export async function generateStaticParams({ params, ...otherProps }:any) {
+  return generateStaticParamsOrigin({ ...otherProps, params, locale: "cs" })
 }
 `
   const inputRewrite = {

--- a/src/cli/templates/lib-declaration-tpl.test.ts
+++ b/src/cli/templates/lib-declaration-tpl.test.ts
@@ -110,8 +110,8 @@ export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, param
  * @deprecated Use GeneratePageStaticParamsProps instead
  */
 export type GenerateStaticParamsProps = { pageLocale: string }
-export type GeneratePageStaticParamsProps = { pageLocale: string }
-export type GenerateLayoutStaticParamsProps = { locale: string }
+export type GeneratePageStaticParamsProps<TParams = any> = { pageLocale: string, params: TParams }
+export type GenerateLayoutStaticParamsProps<TParams = any> = { locale: string, params: TParams }
 `
 
   test('should create lib declaration', () => {
@@ -186,8 +186,8 @@ export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, param
  * @deprecated Use GeneratePageStaticParamsProps instead
  */
 export type GenerateStaticParamsProps = { pageLocale: string }
-export type GeneratePageStaticParamsProps = { pageLocale: string }
-export type GenerateLayoutStaticParamsProps = { locale: string }
+export type GeneratePageStaticParamsProps<TParams = any> = { pageLocale: string, params: TParams }
+export type GenerateLayoutStaticParamsProps<TParams = any> = { locale: string, params: TParams }
 `
 
   test('should create lib declaration', () => {

--- a/src/cli/templates/lib-declaration-tpl.ts
+++ b/src/cli/templates/lib-declaration-tpl.ts
@@ -51,8 +51,8 @@ export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, param
  * @deprecated Use GeneratePageStaticParamsProps instead
  */
 export type GenerateStaticParamsProps = { pageLocale: string }
-export type GeneratePageStaticParamsProps = { pageLocale: string }
-export type GenerateLayoutStaticParamsProps = { locale: string }
+export type GeneratePageStaticParamsProps<TParams = any> = { pageLocale: string, params: TParams }
+export type GenerateLayoutStaticParamsProps<TParams = any> = { locale: string, params: TParams }
 `
 
 export const tplWithDynamicRoutes = `
@@ -96,8 +96,8 @@ export type GenerateLayoutMetadataProps<TParams = any> = { locale: string, param
  * @deprecated Use GeneratePageStaticParamsProps instead
  */
 export type GenerateStaticParamsProps = { pageLocale: string }
-export type GeneratePageStaticParamsProps = { pageLocale: string }
-export type GenerateLayoutStaticParamsProps = { locale: string }
+export type GeneratePageStaticParamsProps<TParams = any> = { pageLocale: string, params: TParams }
+export type GenerateLayoutStaticParamsProps<TParams = any> = { locale: string, params: TParams }
 `
 
 function not<T>(fn: (input: T) => boolean) {

--- a/src/cli/templates/page-tpl.test.ts
+++ b/src/cli/templates/page-tpl.test.ts
@@ -214,8 +214,8 @@ export async function generateMetadata({ params, ...otherProps }:any) {
 
 import {generateStaticParams as generateStaticParamsOrigin} from '../../../../../roots/blog/[authorId]/page'
 
-export async function generateStaticParams() {
-  return generateStaticParamsOrigin({ pageLocale: "cs" })
+export async function generateStaticParams({ params, ...otherProps }:any) {
+  return generateStaticParamsOrigin({ ...otherProps, params, pageLocale: "cs" })
 }
 `
   const inputRewrite = {


### PR DESCRIPTION
### Description

In order to support the "Generate params from the top down" pattern of nextjs, we now pass the `params` received by `generateStaticParams` to the origin function `generateStaticParamsOrigin`

fix #242

### Question
I'm unsure about the modification required for the test `"should create page for [dynamic] route with generate static params and generateMetadata functions"` in `src/cli/templates/page-tpl.test.ts`.

The actual test is targeting both `generateMetadata` and `generateStaticParams`. And so, I just changed the expected parameter for `generateStaticParams`. 

Should we consider splitting this test to be more isolated ? Any guidance would be appreciated.

**Note:** This PR is marked as a draft until I receive feedback on the test modification.
