### PR TITLE
feat(routes): support all types of exports

### DIFF
--- a/src/cli/templates/decorators/with-layout-generate-static-params.ts
+++ b/src/cli/templates/decorators/with-layout-generate-static-params.ts
@@ -23,7 +23,7 @@ export function withLayoutGenerateStaticParamsFactory(
   if (
     params
       .getOriginContents()
-      .match(/export async function generateStaticParams/g)
+      .match(/export .+ generateStaticParams/g)
   ) {
     return withLayoutGenerateStaticParams
   }

--- a/src/cli/templates/decorators/with-layout-metadata.ts
+++ b/src/cli/templates/decorators/with-layout-metadata.ts
@@ -44,12 +44,12 @@ export function withLayoutMetadataDecoratorFactory(
   params: DecoratorParams
 ): CompileFn {
   if (
-    params.getOriginContents().match(/export async function generateMetadata/g)
+    params.getOriginContents().match(/export .+ generateMetadata/g)
   ) {
     return withLayoutDynamicMetaDataFactory(params.getRewrite())
   }
 
-  if (params.getOriginContents().match(/export const metadata/g)) {
+  if (params.getOriginContents().match(/export .+ metadata/g)) {
     return withLayoutStaticMetaData
   }
 

--- a/src/cli/templates/decorators/with-layout-viewport.ts
+++ b/src/cli/templates/decorators/with-layout-viewport.ts
@@ -43,11 +43,11 @@ export function withLayoutDynamicViewportFactory(rewrite: Rewrite) {
 export function withLayoutViewportDecoratorFactory(
   params: DecoratorParams
 ): CompileFn {
-  if (params.getOriginContents().match(/export function generateViewport/g)) {
+  if (params.getOriginContents().match(/export .+ generateViewport/g)) {
     return withLayoutDynamicViewportFactory(params.getRewrite())
   }
 
-  if (params.getOriginContents().match(/export const viewport/g)) {
+  if (params.getOriginContents().match(/export .+ viewport/g)) {
     return withLayoutStaticViewport
   }
 

--- a/src/cli/templates/decorators/with-page-generate-static-params.ts
+++ b/src/cli/templates/decorators/with-page-generate-static-params.ts
@@ -23,7 +23,7 @@ export function withPageGenerateStaticParamsFactory(
   if (
     params
       .getOriginContents()
-      .match(/export async function generateStaticParams/g)
+      .match(/export .+ generateStaticParams/g)
   ) {
     return withPageGenerateStaticParams
   }

--- a/src/cli/templates/decorators/with-page-metadata.ts
+++ b/src/cli/templates/decorators/with-page-metadata.ts
@@ -60,12 +60,12 @@ export function withPageMetadataDecoratorFactory(
   params: DecoratorParams
 ): CompileFn {
   if (
-    params.getOriginContents().match(/export async function generateMetadata/g)
+    params.getOriginContents().match(/export .+ generateMetadata/g)
   ) {
     return withPageDynamicMetaDataFactory(params.getRewrite())
   }
 
-  if (params.getOriginContents().match(/export const metadata/g)) {
+  if (params.getOriginContents().match(/export .+ metadata/g)) {
     return withPageStaticMetaData
   }
 

--- a/src/cli/templates/decorators/with-page-viewport.ts
+++ b/src/cli/templates/decorators/with-page-viewport.ts
@@ -59,11 +59,11 @@ export function withPageDynamicViewportFactory(rewrite: Rewrite) {
 export function withPageViewportDecoratorFactory(
   params: DecoratorParams
 ): CompileFn {
-  if (params.getOriginContents().match(/export function generateViewport/g)) {
+  if (params.getOriginContents().match(/export .+ generateViewport/g)) {
     return withPageDynamicViewportFactory(params.getRewrite())
   }
 
-  if (params.getOriginContents().match(/export const viewport/g)) {
+  if (params.getOriginContents().match(/export .+ viewport/g)) {
     return withPageStaticViewport
   }
 


### PR DESCRIPTION
fix [#398](https://github.com/svobik7/next-roots/issues/395)

Use regexes instead of strings to search the export patterns, so that all types of export are supported.