### PR TITLE
feat: add getLayout implementation for recommended layout functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 
 .vscode/*
 *.code-workspace
+.idea
 
 # Local History for Visual Studio Code
 .history/
@@ -36,7 +37,7 @@ yarn-error.log*
 # example yarn.lock
 /example/yarn.lock
 
-# automatically generated files & folders 
+# automatically generated files & folders
 /example/pages
 /example/roots.schema.js
 /example/roots.schema.*.js

--- a/example/components/layout/layout-main.tsx
+++ b/example/components/layout/layout-main.tsx
@@ -69,6 +69,11 @@ export default function LayoutMain({ children }) {
             <a>Detail - Article</a>
           </RootLink>
         </li>
+        <li>
+          <RootLink href="get-layout">
+            <a>Get Layout</a>
+          </RootLink>
+        </li>
       </ol>
 
       <h2>Mutations</h2>

--- a/example/domains/get-layout/get-layout.module.css
+++ b/example/domains/get-layout/get-layout.module.css
@@ -1,0 +1,7 @@
+.root {
+  color: red;
+}
+
+.layout {
+  background: pink;
+}

--- a/example/domains/get-layout/get-layout.tsx
+++ b/example/domains/get-layout/get-layout.tsx
@@ -1,0 +1,7 @@
+import styles from './get-layout.module.css'
+
+function GetLayout() {
+  return <div className={styles.root}>GetLayout Domain</div>
+}
+
+export default GetLayout

--- a/example/domains/get-layout/index.tsx
+++ b/example/domains/get-layout/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './get-layout'

--- a/example/roots.config.js
+++ b/example/roots.config.js
@@ -141,5 +141,15 @@ module.exports = {
       ],
       metaData: [{ locale: '*', data: { background: 'cyan' } }],
     },
+
+    {
+      root: 'get-layout',
+      pages: [
+        { locale: 'en', path: 'get-layout' },
+        { locale: 'cs', path: 'ziskej-rozvrzeni' },
+        { locale: 'es', path: 'obtener-el-diseno' },
+      ],
+      metaData: [{ locale: '*', data: { background: 'pink' } }],
+    },
   ],
 }

--- a/example/roots/_app.tsx
+++ b/example/roots/_app.tsx
@@ -1,9 +1,15 @@
 import { detectRoots, RootsContext } from 'next-roots/context'
-import { AppProps } from 'next/app'
+import type { AppProps } from 'next/app'
 import schemaRoots from 'roots.schema'
+
+// Allow pages to export a getLayout function
+type NextPageWithLayout = AppProps['Component'] & {
+  getLayout?: (page: React.ReactElement) => React.ReactNode
+}
 
 function MyApp(props: AppProps) {
   const { Component, pageProps } = props
+  const PageComponent = Component as NextPageWithLayout
 
   // detect roots context from page component
   const roots = detectRoots(props, {
@@ -11,9 +17,12 @@ function MyApp(props: AppProps) {
     locales: schemaRoots.locales,
   })
 
+  // use page's getLayout or fallback to identity (no layout)
+  const getLayout = PageComponent.getLayout ?? ((page) => page)
+
   return (
     <RootsContext.Provider value={roots}>
-      <Component {...pageProps} />
+      {getLayout(<PageComponent {...pageProps} />)}
     </RootsContext.Provider>
   )
 }

--- a/example/roots/get-layout.tsx
+++ b/example/roots/get-layout.tsx
@@ -5,6 +5,6 @@ function GetLayoutPage() {
   return <GetLayout />
 }
 
-GetLayoutPage.getLayout = (page) => <div className={styles.layout}>admkakasdkmsad{page}</div>
+GetLayoutPage.getLayout = (page) => <div className={styles.layout}>{page}</div>
 
 export default GetLayoutPage

--- a/example/roots/get-layout.tsx
+++ b/example/roots/get-layout.tsx
@@ -1,0 +1,10 @@
+import styles from './../domains/get-layout/get-layout.module.css'
+import GetLayout from '../domains/get-layout'
+
+function GetLayoutPage() {
+  return <GetLayout />
+}
+
+GetLayoutPage.getLayout = (page) => <div className={styles.layout}>admkakasdkmsad{page}</div>
+
+export default GetLayoutPage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-roots",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Next.js utility to generate internationalized pages with metadata according to custom roots rules.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/bin/builder.ts
+++ b/src/bin/builder.ts
@@ -229,6 +229,7 @@ function createPageContent(
   )
   const hasGetStaticPaths = hasSpecialMethod(rootContent, 'getStaticPaths')
   const hasGetStaticProps = hasSpecialMethod(rootContent, 'getStaticProps')
+  const hasGetLayout = hasSpecialMethod(rootContent, 'getLayout');
 
   // parse page rule
   const [pageRoot, pageLocale = ''] = decodeSchemaRuleKey(pageRule.key)
@@ -261,6 +262,7 @@ function createPageContent(
     hasGetServerSideProps,
     hasGetStaticPaths,
     hasGetStaticProps,
+    hasGetLayout,
     useTypings: cfg.useTypings,
   })
 }
@@ -272,12 +274,9 @@ function createPageContent(
  * @param name
  */
 function hasSpecialMethod(content: string, name: string): boolean {
-  return (
-    null !==
-    content.match(
-      new RegExp(`export (const|var|let|async function|function) ${name}`)
-    )
-  )
+  const exportPattern = new RegExp(`export\\s+(const|var|let|async function|function)\\s+${name}`);
+  const assignmentPattern = new RegExp(`\\.${name}\\s*=`);
+  return exportPattern.test(content) || assignmentPattern.test(content);
 }
 
 /**

--- a/src/templates/page.tpl.ts
+++ b/src/templates/page.tpl.ts
@@ -12,6 +12,7 @@ export type PageTemplateProps = {
   hasGetServerSideProps?: boolean
   hasGetInitialProps?: boolean
   useTypings?: boolean
+  hasGetLayout?: boolean
 }
 
 export default function pageTemplate(props: PageTemplateProps) {
@@ -29,6 +30,7 @@ export default function pageTemplate(props: PageTemplateProps) {
     hasGetServerSideProps = false,
     hasGetInitialProps = false,
     useTypings = true,
+    hasGetLayout = false
   } = props
 
   // const pageMeta = meta?.find(m => m);
@@ -149,6 +151,11 @@ export default function pageTemplate(props: PageTemplateProps) {
 
     tpl +=
       `export const ${methodName} = async () => __root.getStaticPaths()` + `\n`
+  }
+
+  if (hasGetLayout) {
+    tpl += `\n`
+    tpl += `${pageName}Page.getLayout = ${pageName}Root.getLayout` + `\n`
   }
 
   tpl += `\n`


### PR DESCRIPTION
This PR adds recommended way to add per-page layout as in the docs to the V2 of next-roots package.

https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#per-page-layouts